### PR TITLE
correção do título da tela de senha

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1132,7 +1132,7 @@ class FunctionsOfLogin(GeneralFunctions):
 
     def password_window(self, function, parameter):
         self.passwordWindow = Toplevel()
-        self.passwordWindow.title('Senha de administrador - Studio Rosa')
+        self.passwordWindow.title('Senha de administrador - BlackBelt-Pro')
         width = self.passwordWindow.winfo_screenwidth()
         height = self.passwordWindow.winfo_screenheight()
         posx = width / 2 - 340 / 2


### PR DESCRIPTION
Título da tela de senha corrigido
![image](https://github.com/user-attachments/assets/2252cbf6-2ed8-4086-82a1-daa146d7d208)
